### PR TITLE
Fix: Using 'this' for global object doesn't work in strict mode

### DIFF
--- a/tools/wrap.start
+++ b/tools/wrap.start
@@ -8,6 +8,6 @@
         // Browser globals
         root.principium = factory(root.$, root._);
     }
-}(this, function ($, _) {
+}(window, function ($, _) {
 
 


### PR DESCRIPTION
Using `this` keyword for referring to the global object doesn't work in strict mode. For one thing, this makes it impossible to run babel on the library after using this wrapper.

Some good information here (using the `globalThis` keyword also solves the problem, but may be less compatible with very old browsers):
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
